### PR TITLE
Fix blinking badge for good

### DIFF
--- a/src/lib/components/BlinkingBadge.svelte
+++ b/src/lib/components/BlinkingBadge.svelte
@@ -15,6 +15,7 @@
 	let shouldShowPulse = false;
 
 	onMount(() => {
+		if (!storedDateItem) return;
 		const storedDateStore = localStorageStore(storedDateItem, "");
 		const storedDate = get(storedDateStore).replace(/"/g, "");
 		const lastVisitItem = localStorage.getItem("lastVisit");

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -264,7 +264,7 @@
 			<Tabs.List class="bg-input dark:bg-muted">
 				{#each typedEntries(repos) as [id, { name }]}
 					<BlinkingBadge
-						storedDateItem="{id.toLowerCase()}MostRecentUpdate"
+						storedDateItem="{id}MostRecentUpdate"
 						show={!visitedTabs.includes(id) && id !== currentRepo}
 					>
 						<Tabs.Trigger


### PR DESCRIPTION
After having introduced the feature (c596154c1799429ba1f6140bf1fe8b893a791f88) and attempting to fix it partly multiple times (53de4fdce6353f2417ad4d473756cafacc5400f2, a3439e108fabdcfc434d4c614e02501864218d0c & ee6ce3ea6e3f6a69a33fff7cebdd65c164d37800), I'm noticing it's still not properly functioning.

> How could you mess it up 4 times?

you might ask. Well, because believe it or not: _it works on my machine_ (I know, this is a first in software engineering).

Most of the fixes I made in the 3 part-commit were obvious look-at-the-code fixes, which fixed half of it (pulsing dots in the list) but not the second part of it (actual blinking badges for the segment selector).

So, as I can't start a preview (prod) build locally because of the Vercel adapter, I'm going to try reproducing it and fixing it for good using the Preview builds from Vercel in this PR.

Let's do it.