### PR TITLE
Sidebar v2

### DIFF
--- a/src/routes/package/[...package]/+page.server.ts
+++ b/src/routes/package/[...package]/+page.server.ts
@@ -3,90 +3,123 @@ import semver from "semver";
 import { gitHubCache, type GitHubRelease } from "$lib/server/github-cache";
 import { discoverer } from "$lib/server/package-discoverer";
 import type { Repository } from "$lib/repositories";
+import type { Prettify } from "$lib/types";
 
-export async function load({ params }) {
-	const { package: slugPackage } = params;
-	const categorizedPackages = await discoverer.getOrDiscoverCategorized();
-
+async function getReleases(
+	packageName: string,
+	allPackages: Awaited<ReturnType<typeof discoverer.getOrDiscoverCategorized>>
+) {
 	let currentPackage:
-		| (Omit<Repository, "dataFilter" | "metadataFromTag" | "changelogContentsReplacer"> &
-				Pick<(typeof categorizedPackages)[number]["packages"][number], "pkg">)
+		| Prettify<
+				Omit<Repository, "dataFilter" | "metadataFromTag" | "changelogContentsReplacer"> &
+					Pick<(typeof allPackages)[number]["packages"][number], "pkg">
+		  >
 		| undefined = undefined;
 	const foundVersions = new Set<string>();
 	const releases: ({ cleanName: string; cleanVersion: string } & GitHubRelease)[] = [];
 
 	// Discover releases
 	console.log("Starting loading releases...");
-	for (const { category, packages } of categorizedPackages) {
+	for (const { category, packages } of allPackages) {
 		for (const { pkg, ...repo } of packages) {
-			if (pkg.name.toLowerCase() === slugPackage.toLowerCase()) {
-				// 1. Get releases
-				const cachedReleases = await gitHubCache.getReleases({ ...repo, category });
-				console.log(
-					`${cachedReleases.length} releases found for repo ${repo.owner}/${repo.repoName}`
-				);
+			if (pkg.name.localeCompare(packageName, undefined, { sensitivity: "base" }) !== 0) continue;
 
-				// 2. Filter out invalid ones
-				const validReleases = cachedReleases
-					.filter(release => {
-						const [name] = repo.metadataFromTag(release.tag_name);
-						return (
-							(repo.dataFilter?.(release) ?? true) &&
-							slugPackage.localeCompare(name, undefined, { sensitivity: "base" }) === 0
-						);
-					})
-					.sort((a, b) => {
-						const [, firstVersion] = repo.metadataFromTag(a.tag_name);
-						const [, secondVersion] = repo.metadataFromTag(b.tag_name);
-						return semver.rcompare(firstVersion, secondVersion);
-					});
-				console.log("Length after filtering:", validReleases.length);
-				// Get the releases matching the slug, or all of them if none
-				// (the latter case for repos with no package in names)
-				console.log("Final filtered count:", validReleases.length);
+			// 1. Get releases
+			const cachedReleases = await gitHubCache.getReleases({ ...repo, category });
+			console.log(
+				`${cachedReleases.length} releases found for repo ${repo.owner}/${repo.repoName}`
+			);
 
-				// 3. For each release, check if it is already found, searching by versions
-				const { dataFilter, metadataFromTag, changelogContentsReplacer, ...rest } = repo;
-				for (const release of validReleases) {
-					const [cleanName, cleanVersion] = repo.metadataFromTag(release.tag_name);
-					console.log(`Release ${release.tag_name}, extracted version: ${cleanVersion}`);
-					if (foundVersions.has(cleanVersion)) continue;
+			// 2. Filter out invalid ones
+			const validReleases = cachedReleases
+				.filter(release => {
+					const [name] = repo.metadataFromTag(release.tag_name);
+					return (
+						(repo.dataFilter?.(release) ?? true) &&
+						pkg.name.localeCompare(name, undefined, { sensitivity: "base" }) === 0
+					);
+				})
+				.sort((a, b) => {
+					const [, firstVersion] = repo.metadataFromTag(a.tag_name);
+					const [, secondVersion] = repo.metadataFromTag(b.tag_name);
+					return semver.rcompare(firstVersion, secondVersion);
+				});
+			console.log("Length after filtering:", validReleases.length);
+			// Get the releases matching the slug, or all of them if none
+			// (the latter case for repos with no package in names)
+			console.log("Final filtered count:", validReleases.length);
 
-					// If not, add its version to the set and itself to the final version
-					const currentNewestVersion = [...foundVersions].sort(semver.rcompare)[0];
-					console.log("Current newest version", currentNewestVersion);
-					foundVersions.add(cleanVersion);
-					releases.push({ cleanName, cleanVersion, ...release });
+			// 3. For each release, check if it is already found, searching by versions
+			const { dataFilter, metadataFromTag, changelogContentsReplacer, ...rest } = repo;
+			for (const release of validReleases) {
+				const [cleanName, cleanVersion] = repo.metadataFromTag(release.tag_name);
+				console.log(`Release ${release.tag_name}, extracted version: ${cleanVersion}`);
+				if (foundVersions.has(cleanVersion)) continue;
 
-					// If it is newer than the newest we got, set this repo as the "final repo"
-					if (!currentNewestVersion || semver.gt(cleanVersion, currentNewestVersion)) {
-						console.log(
-							`Current newest version "${currentNewestVersion}" doesn't exist or is lesser than ${cleanVersion}, setting ${rest.owner}/${rest.repoName} as final repo`
-						);
-						currentPackage = {
-							category,
-							pkg,
-							...rest
-						};
-					}
+				// If not, add its version to the set and itself to the final version
+				const currentNewestVersion = [...foundVersions].sort(semver.rcompare)[0];
+				console.log("Current newest version", currentNewestVersion);
+				foundVersions.add(cleanVersion);
+				releases.push({ cleanName, cleanVersion, ...release });
+
+				// If it is newer than the newest we got, set this repo as the "final repo"
+				if (!currentNewestVersion || semver.gt(cleanVersion, currentNewestVersion)) {
+					console.log(
+						`Current newest version "${currentNewestVersion}" doesn't exist or is lesser than ${cleanVersion}, setting ${rest.owner}/${rest.repoName} as final repo`
+					);
+					currentPackage = {
+						category,
+						pkg,
+						...rest
+					};
 				}
-				console.log("Done");
 			}
+			console.log("Done");
 		}
 	}
 
-	if (currentPackage) {
-		// Return the final sorted results
-		return {
-			currentPackage,
-			releases: releases.toSorted(
-				(a, b) =>
-					new Date(b.published_at ?? b.created_at).getTime() -
-					new Date(a.published_at ?? a.created_at).getTime()
-			)
-		};
-	}
+	return currentPackage
+		? {
+				releasesRepo: currentPackage,
+				releases: releases.toSorted(
+					(a, b) =>
+						new Date(b.published_at ?? b.created_at).getTime() -
+						new Date(a.published_at ?? a.created_at).getTime()
+				)
+			}
+		: undefined;
+}
 
-	// If this one doesn't exist, return 404
-	error(404);
+async function getAllOtherReleases(exceptPackage: string) {
+	const discovery = await discoverer.getOrDiscoverCategorized();
+	const otherPackages = discovery.flatMap(({ packages }) => packages);
+
+	const otherReleases = await Promise.all(
+		otherPackages.map(async otherPackage => await getReleases(otherPackage.pkg.name, discovery))
+	);
+
+	return otherReleases
+		.filter(o => o !== undefined)
+		.filter(
+			({ releasesRepo: releasesPackage }) =>
+				releasesPackage.pkg.name.localeCompare(exceptPackage, undefined, {
+					sensitivity: "base"
+				}) !== 0
+		);
+}
+
+export async function load({ params }) {
+	const { package: slugPackage } = params;
+	const categorizedPackages = await discoverer.getOrDiscoverCategorized();
+
+	const computedReleases = await getReleases(slugPackage, categorizedPackages);
+
+	if (!computedReleases) error(404);
+
+	const { releasesRepo: currentPackage, releases } = computedReleases;
+	return {
+		currentPackage,
+		releases,
+		otherReleases: getAllOtherReleases(currentPackage.pkg.name)
+	};
 }

--- a/src/routes/package/[...package]/+page.svelte
+++ b/src/routes/package/[...package]/+page.svelte
@@ -88,6 +88,7 @@
 						headless
 						packageName={data.currentPackage.pkg.name}
 						allPackages={data.displayablePackages}
+						otherReleases={data.otherReleases}
 						bind:showPrereleases
 						class="my-8"
 					/>
@@ -134,6 +135,7 @@
 			<SidePanel
 				packageName={data.currentPackage.pkg.name}
 				allPackages={data.displayablePackages}
+				otherReleases={data.otherReleases}
 				class="hidden h-fit w-140 lg:block"
 				bind:showPrereleases
 			/>


### PR DESCRIPTION
The sidebar currently looks fine but lacks a lot of functionality, especially when it comes to long package lists (e.g., the "Other" category).

The purpose of this PR is not only to help figure out what's new right from the list, but also to provide a more compact view when there is a large number of packages in some sections.

This PR will be controversially quite large, but the sidebar will be good after this.

### Features
- Add badges for packages that have unseen releases since the last visit (new visitors are _not_ concerned)
- Collapse large sections into a short list of 5 packages at most
  - Allow clicking an "Expand" button to see all the packages (and morph it into a "Collapse" button once the list is expanded)

### Roadmap
#### Badges
- [x] Stream in the releases for all the packages
- [ ] Avoid rerunning this streaming on package change
- [ ] Create the badges from Snippets
- [ ] Use `localStorage` to store the last visit for each package, only show the releases more recent than `localStorage` on the badge
- [ ] Update the `localStorage` value on a package visit

#### Section collapsing
- [ ] Create the Collapse/Expand button for large sections (1 per section)
  - [ ] Animate the collapsing/expansion?
- [ ] Show the packages that have the largest number of releases, sorted by most releases, when collapsed
  - [ ] If the expansion/collapsing is animated, also animate the list items or sort them after the other animation