### PR TITLE
feat: handle deprecated packages

### DIFF
--- a/src/lib/server/github-cache.ts
+++ b/src/lib/server/github-cache.ts
@@ -18,6 +18,7 @@ export type GitHubRelease = Awaited<
 >["data"][number];
 
 type KeyType = "releases" | "descriptions" | "issue" | "pr";
+type CachedValue<T> = { value: T; cache: boolean };
 
 export type ItemDetails = {
 	comments: Awaited<ReturnType<Issues["listComments"]>>["data"];
@@ -70,6 +71,10 @@ const FULL_DETAILS_TTL = 60 * 60 * 2; // 2 hours
  * The TTL of the cached descriptions, in seconds.
  */
 const DESCRIPTIONS_TTL = 60 * 60 * 24 * 10; // 10 days
+/**
+ * The TTL for non-deprecated packages, in seconds
+ */
+const DEPRECATIONS_TTL = 60 * 60 * 24 * 2; // 2 days
 
 /**
  * A fetch layer to reach the GitHub API
@@ -116,6 +121,21 @@ export class GitHubCache {
 	}
 
 	/**
+	 * Generates a Redis key from the passed info.
+	 *
+	 * @param packageName the package name
+	 * @param args the optional additional values to append
+	 * at the end of the key; every element will be interpolated
+	 * in a string
+	 * @returns the pure computed key
+	 * @private
+	 */
+	#getPackageKey(packageName: string, ...args: unknown[]) {
+		const strArgs = args.map(a => `:${a}`);
+		return `package:${packageName}${strArgs}`;
+	}
+
+	/**
 	 * An abstraction over general processing that:
 	 * 1. tries getting stuff from Redis cache
 	 * 2. calls the promise to get new data if no value is found in cache
@@ -124,6 +144,10 @@ export class GitHubCache {
 	 * @private
 	 */
 	#processCached<RType extends Parameters<InstanceType<typeof Redis>["json"]["set"]>[2]>() {
+		function isCachedValue<T>(item: T | CachedValue<T>): item is CachedValue<T> {
+			return typeof item === "object" && item !== null && "value" in item && "cache" in item;
+		}
+
 		/**
 		 * Inner currying function to circumvent unsupported partial inference
 		 *
@@ -137,8 +161,10 @@ export class GitHubCache {
 		return async <PromiseType>(
 			cacheKey: string,
 			promise: () => Promise<PromiseType>,
-			transformer: (from: Awaited<PromiseType>) => RType | Promise<RType>,
-			ttl: number | undefined = undefined
+			transformer: (
+				from: Awaited<PromiseType>
+			) => RType | CachedValue<RType> | Promise<RType> | Promise<CachedValue<RType>>,
+			ttl: number | ((value: RType) => number | undefined) | undefined = undefined
 		): Promise<RType> => {
 			const cachedValue = await this.#redis.json.get<RType>(cacheKey);
 			if (cachedValue) {
@@ -148,11 +174,25 @@ export class GitHubCache {
 
 			console.log(`Cache miss for ${cacheKey}`);
 
-			const newValue = await transformer(await promise());
+			let newValue = await transformer(await promise());
+			let wantsCache = true;
+			if (isCachedValue(newValue)) {
+				wantsCache = newValue.cache;
+				newValue = newValue.value;
+			}
 
-			await this.#redis.json.set(cacheKey, "$", newValue);
-			if (ttl !== undefined) {
-				await this.#redis.expire(cacheKey, ttl);
+			if (wantsCache) {
+				await this.#redis.json.set(cacheKey, "$", newValue);
+				if (ttl !== undefined) {
+					if (typeof ttl === "function") {
+						const ttlResult = ttl(newValue);
+						if (ttlResult !== undefined) {
+							await this.#redis.expire(cacheKey, ttlResult);
+						}
+					} else {
+						await this.#redis.expire(cacheKey, ttl);
+					}
+				}
 			}
 
 			return newValue;
@@ -537,7 +577,6 @@ export class GitHubCache {
 	 * @param repo the GitHub repository name to fetch the
 	 * descriptions in
 	 * @returns a map of paths to descriptions.
-	 * @private
 	 */
 	async getDescriptions(owner: string, repo: string) {
 		return await this.#processCached<{ [key: string]: string }>()(
@@ -584,6 +623,35 @@ export class GitHubCache {
 				return Object.fromEntries(descriptions);
 			},
 			DESCRIPTIONS_TTL
+		);
+	}
+
+	/**
+	 * Get the deprecation state of a package from its name.
+	 *
+	 * @param packageName the name of the package to search
+	 * @returns the deprecation status message if any, `false` otherwise
+	 */
+	async getPackageDeprecation(packageName: string) {
+		return await this.#processCached<string | false>()(
+			this.#getPackageKey(packageName, "deprecation"),
+			async () => {
+				try {
+					const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`);
+					if (res.status !== 200) return {};
+					return (await res.json()) as { deprecated?: boolean | string };
+				} catch (error) {
+					console.error(`Error fetching npmjs.org for package ${packageName}:`, error);
+					return {};
+				}
+			},
+			({ deprecated }) => {
+				if (deprecated === undefined) return false;
+				if (typeof deprecated === "boolean")
+					return { value: "This package is deprecated", cache: false };
+				return { value: deprecated || "This package is deprecated", cache: false };
+			},
+			item => (item === false ? DEPRECATIONS_TTL : undefined)
 		);
 	}
 }

--- a/src/lib/server/package-discoverer.ts
+++ b/src/lib/server/package-discoverer.ts
@@ -5,6 +5,7 @@ import { GitHubCache, gitHubCache } from "./github-cache";
 type Package = {
 	name: string;
 	description: string;
+	deprecated?: string;
 };
 
 export type DiscoveredPackage = Prettify<
@@ -54,19 +55,22 @@ export class PackageDiscoverer {
 				);
 				return {
 					...repo,
-					packages: packages.map(pkg => {
-						const ghName = this.#gitHubDirectoryFromName(pkg);
-						return {
-							name: pkg,
-							description:
-								descriptions[`packages/${ghName}/package.json`] ??
-								descriptions[
-									`packages/${ghName.substring(ghName.lastIndexOf("/") + 1)}/package.json`
-								] ??
-								descriptions["package.json"] ??
-								""
-						};
-					})
+					packages: await Promise.all(
+						packages.map(async (pkg): Promise<Package> => {
+							const ghName = this.#gitHubDirectoryFromName(pkg);
+							return {
+								name: pkg,
+								description:
+									descriptions[`packages/${ghName}/package.json`] ??
+									descriptions[
+										`packages/${ghName.substring(ghName.lastIndexOf("/") + 1)}/package.json`
+									] ??
+									descriptions["package.json"] ??
+									"",
+								deprecated: (await this.#cache.getPackageDeprecation(pkg)) || undefined
+							};
+						})
+					)
 				};
 			})
 		);


### PR DESCRIPTION
With `@sveltejs/adapter-cloudflare-workers` [being deprecated](https://github.com/sveltejs/kit/pull/13634), the site does not provide any information in that direction, potentially leading the user to wonder why this package is not getting updates anymore.

This PR fixes that by introducing visual hints to the users about the status of deprecated packages by fetching [npmjs.org](https://www.npmjs.com/package/@sveltejs/adapter-cloudflare-workers).
This is not using GitHub, because packages might have been deleted from the repository (as it's the case here), and packages on npmjs [will live forever](https://docs.npmjs.com/unpublishing-packages-from-the-registry), hopefully providing their deprecation status.

### Roadmap

#### Backend

- [x] Create the backend and caching system
- [x] Call the backend function during package object creation

#### Frontend

- [ ] Create a badge in the sidebar
- [ ] Create a banner on the package's page