### PR TITLE
fix(details): fix URL scheme returning a 404 for redirect feature

### DIFF
--- a/src/params/gh.ts
+++ b/src/params/gh.ts
@@ -1,5 +1,3 @@
 export function match(param) {
-	const matches = param.replace(/^https?:\/\/?/, "") === "github.com";
-	console.log(`${param} matches? ${matches}.`);
-	return matches;
+	return param.replace(/^https?:\/\/?/, "") === "github.com";
 }


### PR DESCRIPTION
For some obscure reason, with Vercel/prod deployments, the GH URL you prefix SC's domain with throws a 404, where in dev or preview builds it works fine.

Turns out, as we could see in the URL with this 404 page, the `//` of the URL scheme gets dedup'd on prod builds.
The fix is simply to match **one or** two slashes, that's it.

(Had to make a PR to try it out with prod builds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL parsing robustness to handle GitHub-related URLs with varying slash patterns more consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->