### PR TITLE
ci: fix workflow not working for forks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,7 +48,7 @@ jobs:
       - name: 📂 Checkout
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.repository.full_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref }}
           token: ${{ needs.permissions-check.outputs.has-permissions == 'false' && github.token || secrets.WORKFLOW_PAT }}
           fetch-depth: ${{ github.event_name == 'push' && 2 || 1 }}


### PR DESCRIPTION
This fixes the CI of #132 not working because it's a fork, and the checkout doesn't use the actual origin repo for some obscure reason

Shoutout to [StackOverflow](https://stackoverflow.com/a/76408493/12070367)