### PR TITLE
perf: scan repos only once for packages

### DIFF
--- a/src/lib/server/package-discoverer.ts
+++ b/src/lib/server/package-discoverer.ts
@@ -40,28 +40,24 @@ class PackageDiscoverer {
 	 * Populates the result into packages.
 	 */
 	async discoverAll() {
-		const uniqueRepos = uniq(this.#repos, ({ repoOwner, repoName }) => `${repoOwner}/${repoName}`);
-		const releasesMap = Promise.all(
-			uniqueRepos.map(async repo => ({
-				repo: `${repo.repoOwner}/${repo.repoName}`,
-				releases: await this.#cache.getReleases(repo)
-			}))
-		);
-		const descriptionsMap = Promise.all(
-			uniqueRepos.map(async ({ repoOwner: owner, repoName: name }) => ({
-				repo: `${owner}/${name}`,
-				descriptions: await this.#cache.getDescriptions(owner, name)
-			}))
+		const repoData = new Map(
+			await Promise.all(
+				uniq(this.#repos, ({ repoOwner, repoName }) => `${repoOwner}/${repoName}`).map(
+					async repo => {
+						const [releases, descriptions] = await Promise.all([
+							this.#cache.getReleases(repo),
+							this.#cache.getDescriptions(repo.repoOwner, repo.repoName)
+						]);
+						return [`${repo.repoOwner}/${repo.repoName}`, { releases, descriptions }] as const;
+					}
+				)
+			)
 		);
 
 		this.#packages = await Promise.all(
 			this.#repos.map(async repo => {
-				const releases =
-					(await releasesMap).find(({ repo: r }) => r === `${repo.repoOwner}/${repo.repoName}`)
-						?.releases ?? [];
-				const descriptions =
-					(await descriptionsMap).find(({ repo: r }) => r === `${repo.repoOwner}/${repo.repoName}`)
-						?.descriptions ?? {};
+				const { releases = [], descriptions = {} } =
+					repoData.get(`${repo.repoOwner}/${repo.repoName}`) ?? {};
 				const packages = [
 					...new Set(
 						releases


### PR DESCRIPTION
Some repos are split into multiple categories. Currently, SvelteKit is the only one in that case (see [`$lib/repositories.ts`](src/lib/repositories.ts)): it's once for the SvelteKit category, filtering out other packages, and once in the Tooling category with the reversed filter.

The problem is that with my old logic, all the repos were scanned sequentially without any deduplication mechanism.
While it's necessary to run all the entries with different package filters to scan all the relevant packages at the right time, fetching the releases and the `package.json`s for descriptions was **also done N times**.

This PR fixes this by separating these two steps: one that fetches the releases and descriptions uniquely per repository and stores them temporarily in a map-like data structure, and the other, which applies the data filtering on top of those results and aggregates packages.

The goal of this PR is to get the bots to review that to make sure I didn't introduce regressions (as when I tried to do it naively in 77b4439befff50a044b341fae77c76d0d7dd4719, ending up reverting partially in d8679366626c03bac03e14153999ede53dd54030). It is, however, working well from my local tests, so I'm pretty confident.