### PR TITLE
fix: site is down again

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"marked": "^17.0.3",
 		"mode-watcher": "^1.1.0",
 		"octokit": "^5.0.5",
-		"posthog-js": "^1.354.0",
+		"posthog-js": "^1.353.1",
 		"posthog-node": "^5.26.0",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       posthog-js:
-        specifier: ^1.354.0
-        version: 1.354.0
+        specifier: ^1.353.1
+        version: 1.353.1
       posthog-node:
         specifier: ^5.26.0
         version: 5.26.0
@@ -1060,8 +1060,8 @@ packages:
     peerDependencies:
       rollup: '>= 4.0.0'
 
-  '@posthog/types@1.354.0':
-    resolution: {integrity: sha512-sfH1PiThX1YWkrZSls6zMuZcJWnvboCnZEJ3Z/OI8WgBmLDJfQpficbuLM3tgSLIchI22TPAkpwdT987iW6XIA==}
+  '@posthog/types@1.353.1':
+    resolution: {integrity: sha512-8zTsChX8yvYT9t5H1u9fb+qRAetYDIXGRXKDPv7goKyF+cuFFAVofKwlVSZ9W41sS1sYsMMqjXLRJzawgDVXxw==}
 
   '@prgm/sveltekit-progress-bar@3.0.2':
     resolution: {integrity: sha512-RilKiPC2Lt/ahC1qmqvL5B8YJPmpwcz/PVebhOmGA7VRcU97xvbn83428r3pVfRNVlxKjHm9NatbIgQim/ccJA==}
@@ -2797,8 +2797,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.354.0:
-    resolution: {integrity: sha512-qrpToz7mN1PmEfo+Ob4Z8euX4z2p17LA0EAtFeyod3IVnlwnu+Ybea/oxVsPiq5YAPo+p5z73FcjF2yEJ7oZnA==}
+  posthog-js@1.353.1:
+    resolution: {integrity: sha512-yMQQ0sX6oSVqS2n8y8WKzHzX1qcjBibc/ZfomyDAc1PyEz5rmdszR1pA7UBAJOLc3zD0fcw9Gh5M+2QaAgDmoA==}
 
   posthog-node@5.26.0:
     resolution: {integrity: sha512-DK1XF/RiunhvT57cFyPxW9OaliZzl5aREHFwY/AISL3MVOaDUb4wIccMn0G3ws3Ounen8iGH7xvzZQ0x2vEOEQ==}
@@ -4211,7 +4211,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@posthog/types@1.354.0': {}
+  '@posthog/types@1.353.1': {}
 
   '@prgm/sveltekit-progress-bar@3.0.2(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.6)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.6)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)))(svelte@5.53.6)':
     dependencies:
@@ -6020,7 +6020,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.354.0:
+  posthog-js@1.353.1:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
@@ -6028,7 +6028,7 @@ snapshots:
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@posthog/core': 1.23.1
-      '@posthog/types': 1.354.0
+      '@posthog/types': 1.353.1
       core-js: 3.48.0
       dompurify: 3.3.1
       fflate: 0.4.8


### PR DESCRIPTION
trying to figure out why:
```
SyntaxError: Unexpected token 'export'

File "node:diagnostics_channel", line: 328, in: TracingChannel.traceSync
File "/opt/rust/nodejs.js", line: 2, in: Xe.e.<computed>.Ye._load
File "/opt/rust/nodejs.js", line: 2, in: Module.pn
File "/opt/rust/nodejs.js", line: 2
File "node:internal/modules/cjs/loader", line: 1300, in: Module.?
File "node:internal/modules/cjs/loader", line: 1481, in: Module.load
File "node:internal/modules/cjs/loader", line: 1893, in: Object..js
File "/opt/rust/bytecode.js", line: 2, in: A.d._compile
File "node:internal/modules/cjs/loader", line: 1735, in: Module.?
File "node:internal/modules/cjs/loader", line: 1692, in: wrapSafe
```

Update: the culprit is posthog-js 1.354.0+, downgraded and will figure out the actual reason later