### PR TITLE
feat: toggle website theme with keys

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -111,8 +111,7 @@
 		const element = activeElement.current;
 		// avoid impacting interactive elements
 		if (
-			!element ||
-			element.matches(
+			element?.matches(
 				"input:not([type=hidden],[type=submit],[type=button],[type=reset],[type=image]), textarea, select, [contenteditable]"
 			)
 		)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,8 +24,15 @@
 		X
 	} from "@lucide/svelte";
 	import { ProgressBar } from "@prgm/sveltekit-progress-bar";
-	import { ModeWatcher, resetMode, setMode } from "mode-watcher";
-	import { PersistedState } from "runed";
+	import {
+		mode,
+		ModeWatcher,
+		resetMode,
+		setMode,
+		systemPrefersMode,
+		toggleMode
+	} from "mode-watcher";
+	import { activeElement, PersistedState, PressedKeys } from "runed";
 	import { MetaTags, deepMerge } from "svelte-meta-tags";
 	import { uniq } from "$lib/array";
 	import { news } from "$lib/news/news.json";
@@ -95,8 +102,27 @@
 			icon: Monitor
 		}
 	};
-	let theme = $state<keyof typeof themes>("system");
+	let theme = $derived<keyof typeof themes>(
+		mode.current === systemPrefersMode.current ? "system" : (mode.current ?? "system")
+	);
 	let themeSwitcherOpen = $state(false);
+	// change theme on pressing "d"
+	new PressedKeys().onKeys("d", () => {
+		const element = activeElement.current;
+		// avoid impacting interactive elements
+		if (
+			!element ||
+			element.matches(
+				"input:not([type=hidden],[type=submit],[type=button],[type=reset],[type=image]), textarea, select, [contenteditable]"
+			)
+		)
+			return;
+
+		// instead of doing system -> light -> dark -> light -> dark, reset to system if it matches the target mode
+		const systemMode = systemPrefersMode.current;
+		if (systemMode && mode.current && systemMode !== mode.current) resetMode();
+		else toggleMode();
+	});
 
 	// News
 	let newsToDisplay = $state<(typeof news)[number]>();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -83,7 +83,12 @@
 			callback();
 			return;
 		}
-		document.startViewTransition({ update: callback, types });
+		try {
+			document.startViewTransition({ update: callback, types });
+		} catch {
+			// Level 1 browsers don't support the options-object form
+			document.startViewTransition(callback);
+		}
 	}
 	function setMode(mode: Mode) {
 		withViewTransition(() => mwSetMode(mode), "theme");

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,7 +30,8 @@
 		resetMode as mwResetMode,
 		setMode as mwSetMode,
 		systemPrefersMode,
-		toggleMode as mwToggleMode
+		toggleMode as mwToggleMode,
+		userPrefersMode
 	} from "mode-watcher";
 	import { activeElement, PersistedState, PressedKeys } from "runed";
 	import { MetaTags, deepMerge } from "svelte-meta-tags";
@@ -123,9 +124,7 @@
 			icon: Monitor
 		}
 	};
-	let theme = $derived<keyof typeof themes>(
-		mode.current === systemPrefersMode.current ? "system" : (mode.current ?? "system")
-	);
+	let theme = $derived<keyof typeof themes>(userPrefersMode.current ?? "system");
 	let themeSwitcherOpen = $state(false);
 	// change theme on pressing "d"
 	new PressedKeys().onKeys("d", () => {
@@ -139,8 +138,9 @@
 			return;
 
 		// instead of doing system -> light -> dark -> light -> dark, reset to system if it matches the target mode
+		const userMode = userPrefersMode.current ?? "system";
 		const systemMode = systemPrefersMode.current;
-		if (systemMode && mode.current && systemMode !== mode.current) resetMode();
+		if (userMode !== "system" && systemMode && systemMode !== userMode) resetMode();
 		else toggleMode();
 	});
 
@@ -217,12 +217,6 @@
 	let reduceMotion = new MediaQuery("prefers-reduced-motion: reduce");
 
 	$effect(() => {
-		// Theme
-		theme =
-			"mode-watcher-mode" in localStorage
-				? localStorage["mode-watcher-mode"].replaceAll('"', "")
-				: "system";
-
 		// Legacy news key
 		const oldLsNewsKey = "closedNews";
 		const oldLsNewsValue = localStorage.getItem(oldLsNewsKey);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,10 +27,10 @@
 	import {
 		mode,
 		ModeWatcher,
-		resetMode,
-		setMode,
+		resetMode as mwResetMode,
+		setMode as mwSetMode,
 		systemPrefersMode,
-		toggleMode
+		toggleMode as mwToggleMode
 	} from "mode-watcher";
 	import { activeElement, PersistedState, PressedKeys } from "runed";
 	import { MetaTags, deepMerge } from "svelte-meta-tags";
@@ -78,12 +78,28 @@
 			})
 		);
 	});
+	function withViewTransition(callback: () => void, ...types: string[]) {
+		if (!document.startViewTransition) {
+			callback();
+			return;
+		}
+		document.startViewTransition({ update: callback, types });
+	}
+	function setMode(mode: Mode) {
+		withViewTransition(() => mwSetMode(mode), "theme");
+	}
+	function resetMode() {
+		withViewTransition(mwResetMode, "theme");
+	}
+	function toggleMode() {
+		withViewTransition(mwToggleMode, "theme");
+	}
 
 	// SEO
 	let metaTags = $derived(deepMerge(data.baseMetaTags, page.data.pageMetaTags));
 
 	// Theme selector
-	type Mode = Parameters<typeof setMode>[0]; // mode-watcher doesn't export the Mode type
+	type Mode = Parameters<typeof mwSetMode>[0]; // mode-watcher doesn't export the Mode type
 	type Theme = {
 		label: string;
 		icon: typeof Icon;
@@ -446,3 +462,13 @@
 		</p>
 	</div>
 </footer>
+
+<style>
+	:global {
+		html:active-view-transition-type(theme) {
+			&::view-transition-group(root) {
+				animation-duration: 500ms;
+			}
+		}
+	}
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,7 +25,6 @@
 	} from "@lucide/svelte";
 	import { ProgressBar } from "@prgm/sveltekit-progress-bar";
 	import {
-		mode,
 		ModeWatcher,
 		resetMode as mwResetMode,
 		setMode as mwSetMode,


### PR DESCRIPTION
Toggle between light/dark/system mode with the <kbd>d</kbd> key.

### Resources
- [Idea & implementation basis](https://bsky.app/profile/bhidesvelte.bsky.social/post/3mke5qpme7c2z)
- [Runed docs](https://runed.dev/docs/utilities/pressed-keys)

### Left to do
- ~~Decide on eventually changing the key or adding another one~~
- [x] Ensure the toggling logic is correct
- [x] Ensure the now dynamic toggle dropdown/initial theme isn't broken
- [x] Add a famously nice theme transition