### PR TITLE
ci: avoid useless steps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,6 +95,8 @@ jobs:
       - name: 🔍 Get modified files
         id: modified-files
         uses: tj-actions/changed-files@v47
+        with:
+          skip_initial_fetch: true
 
       - name: 📤 Export results
         id: changed-files

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,8 +44,6 @@ jobs:
       - name: 🔍 Get modified files
         id: modified-files
         uses: tj-actions/changed-files@v47
-        with:
-          skip_initial_fetch: true
 
       - name: 📤 Export results
         id: changed-files

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,6 +44,8 @@ jobs:
       - name: 🔍 Get modified files
         id: modified-files
         uses: tj-actions/changed-files@v47
+        with:
+          skip_initial_fetch: true
 
       - name: 📤 Export results
         id: changed-files


### PR DESCRIPTION
Changed files are eagerly fetching against `main` despite the checkout step only being shallow, resulting in useless steps being run due to more files being incorrectly taken into account.