### PR TITLE
fix: safe storage access

### DIFF
--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -1,5 +1,6 @@
 import { browser } from "$app/env";
 import type { GitHubRelease } from "./server/github-api";
+import { local } from "./storage";
 
 /**
  * Extract the data from the record parameter which the key matches the argument.
@@ -30,7 +31,7 @@ export function getBadgeDataFromRecord<T>(
 export function getUnvisitedReleases<T extends GitHubRelease>(pkgName: string, releases: T[]): T[] {
 	if (!releases.length || !browser) return [];
 
-	const lastVisitedItem = localStorage.getItem(`last-visited-${pkgName}`);
+	const lastVisitedItem = local.getItem(`last-visited-${pkgName}`);
 	if (!lastVisitedItem) {
 		// by default, if never visited, "new" packages are those newer than a week
 		return releases.filter(
@@ -56,7 +57,7 @@ export function isPackageNew(pkgName: string, releases: GitHubRelease[]) {
 	if (!browser) return false;
 	if (!releases.length) return true;
 
-	const isVisited = !!localStorage.getItem(`last-visited-${pkgName}`);
+	const isVisited = !!local.getItem(`last-visited-${pkgName}`);
 	if (isVisited) return false;
 
 	const oldestRelease = releases

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,9 +4,24 @@
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#exceptions|MDN}
  */
-function safeStorage(store: Storage) {
+function safeStorage(store: Storage): Storage {
 	return {
-		getItem: (key: string, defaultValue: string | null = null): ReturnType<Storage["getItem"]> => {
+		get length() {
+			try {
+				return store.length;
+			} catch {
+				// disabled or unavailable
+				return 0;
+			}
+		},
+		clear: () => {
+			try {
+				store.clear();
+			} catch {
+				// disabled or unavailable
+			}
+		},
+		getItem: (key, defaultValue: ReturnType<Storage["getItem"]> = null) => {
 			try {
 				return store.getItem(key);
 			} catch {
@@ -14,18 +29,24 @@ function safeStorage(store: Storage) {
 				return defaultValue;
 			}
 		},
-
-		setItem: (key: string, value: string) => {
+		key: (index, defaultValue: ReturnType<Storage["key"]> = null) => {
 			try {
-				store.setItem(key, value);
+				return store.key(index);
+			} catch {
+				// disabled or unavailable
+				return defaultValue;
+			}
+		},
+		removeItem: key => {
+			try {
+				store.removeItem(key);
 			} catch {
 				// disabled or unavailable
 			}
 		},
-
-		removeItem: (key: string) => {
+		setItem: (key, value) => {
 			try {
-				store.removeItem(key);
+				store.setItem(key, value);
 			} catch {
 				// disabled or unavailable
 			}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,49 @@
+/**
+ * A wrapper genrator around `Storage`s to prevent
+ * security errors or incorrect schemes.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#exceptions|MDN}
+ */
+function safeStorage(store: Storage) {
+	return {
+		getItem: (key: string, defaultValue: string | null = null): ReturnType<Storage["getItem"]> => {
+			try {
+				return store.getItem(key);
+			} catch {
+				// disabled or unavailable
+				return defaultValue;
+			}
+		},
+
+		setItem: (key: string, value: string) => {
+			try {
+				store.setItem(key, value);
+			} catch {
+				// disabled or unavailable
+			}
+		},
+
+		removeItem: (key: string) => {
+			try {
+				store.removeItem(key);
+			} catch {
+				// disabled or unavailable
+			}
+		}
+	};
+}
+
+/**
+ * A utility wrapper around `localStorage` to prevent
+ * security errors or incorrect schemes.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#exceptions|MDN}
+ */
+export const local = safeStorage(localStorage);
+/**
+ * A utility wrapper around `sessionStorage` to prevent
+ * security errors or incorrect schemes.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage#exceptions|MDN}
+ */
+export const session = safeStorage(sessionStorage);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,11 +4,11 @@
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#exceptions|MDN}
  */
-function safeStorage(store: Storage): Storage {
+function safeStorage(getStore: () => Storage): Storage {
 	return {
 		get length() {
 			try {
-				return store.length;
+				return getStore().length;
 			} catch {
 				// disabled or unavailable
 				return 0;
@@ -16,14 +16,14 @@ function safeStorage(store: Storage): Storage {
 		},
 		clear: () => {
 			try {
-				store.clear();
+				getStore().clear();
 			} catch {
 				// disabled or unavailable
 			}
 		},
 		getItem: (key, defaultValue: ReturnType<Storage["getItem"]> = null) => {
 			try {
-				return store.getItem(key);
+				return getStore().getItem(key);
 			} catch {
 				// disabled or unavailable
 				return defaultValue;
@@ -31,7 +31,7 @@ function safeStorage(store: Storage): Storage {
 		},
 		key: (index, defaultValue: ReturnType<Storage["key"]> = null) => {
 			try {
-				return store.key(index);
+				return getStore().key(index);
 			} catch {
 				// disabled or unavailable
 				return defaultValue;
@@ -39,14 +39,14 @@ function safeStorage(store: Storage): Storage {
 		},
 		removeItem: key => {
 			try {
-				store.removeItem(key);
+				getStore().removeItem(key);
 			} catch {
 				// disabled or unavailable
 			}
 		},
 		setItem: (key, value) => {
 			try {
-				store.setItem(key, value);
+				getStore().setItem(key, value);
 			} catch {
 				// disabled or unavailable
 			}
@@ -60,11 +60,11 @@ function safeStorage(store: Storage): Storage {
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#exceptions|MDN}
  */
-export const local = safeStorage(localStorage);
+export const local = safeStorage(() => localStorage);
 /**
  * A utility wrapper around `sessionStorage` to prevent
  * security errors or incorrect schemes.
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage#exceptions|MDN}
  */
-export const session = safeStorage(sessionStorage);
+export const session = safeStorage(() => sessionStorage);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,8 +51,9 @@
 	import MarkdownRenderer from "$lib/components/MarkdownRenderer.svelte";
 	import ScreenSize from "$lib/components/ScreenSize.svelte";
 	import Snowflakes from "$lib/components/Snowflakes.svelte";
-	import DesktopNavigation from "./DesktopNavigation.svelte";
 	import { waitFor } from "$lib/reactivity.svelte";
+	import { local } from "$lib/storage";
+	import DesktopNavigation from "./DesktopNavigation.svelte";
 
 	let { data, children } = $props();
 
@@ -155,11 +156,11 @@
 	let newsToDisplay = $state<(typeof news)[number]>();
 	const closedNewsKey = "closed-news";
 	function getClosedNewsIds() {
-		return JSON.parse(localStorage.getItem(closedNewsKey) ?? "[]") as (typeof news)[number]["id"][];
+		return JSON.parse(local.getItem(closedNewsKey) ?? "[]") as (typeof news)[number]["id"][];
 	}
 	function markCurrentNewsAsRead() {
 		if (!newsToDisplay) return;
-		localStorage.setItem(closedNewsKey, JSON.stringify([...getClosedNewsIds(), newsToDisplay.id]));
+		local.setItem(closedNewsKey, JSON.stringify([...getClosedNewsIds(), newsToDisplay.id]));
 		newsToDisplay = undefined;
 	}
 
@@ -213,10 +214,10 @@
 	$effect(() => {
 		// Legacy news key
 		const oldLsNewsKey = "closedNews";
-		const oldLsNewsValue = localStorage.getItem(oldLsNewsKey);
+		const oldLsNewsValue = local.getItem(oldLsNewsKey);
 		if (oldLsNewsValue) {
-			localStorage.setItem(closedNewsKey, oldLsNewsValue);
-			localStorage.removeItem(oldLsNewsKey);
+			local.setItem(closedNewsKey, oldLsNewsValue);
+			local.removeItem(oldLsNewsKey);
 		}
 
 		// News

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -158,9 +158,7 @@
 	const closedNewsKey = "closed-news";
 	function getClosedNewsIds() {
 		try {
-			return JSON.parse(
-				local.getItem(closedNewsKey) ?? "[]"
-			) as (typeof news)[number]["id"][];
+			return JSON.parse(local.getItem(closedNewsKey) ?? "[]") as (typeof news)[number]["id"][];
 		} catch {
 			return [];
 		}

--- a/src/routes/package/[...package]/+page.svelte
+++ b/src/routes/package/[...package]/+page.svelte
@@ -20,6 +20,7 @@
 	import { Skeleton } from "$lib/components/ui/skeleton";
 	import * as Tooltip from "$lib/components/ui/tooltip";
 	import TopBanner from "$lib/components/TopBanner.svelte";
+	import { local } from "$lib/storage";
 	import { getPackageSettings, settingsUtils } from "../settings.svelte";
 	import type { Snapshot } from "./$types";
 	import Header from "./Header.svelte";
@@ -99,11 +100,11 @@
 
 	let lastUpdateDate = $state<Date>();
 	$effect(() => {
-		const lastVisit = localStorage.getItem(
+		const lastVisit = local.getItem(
 			`last-visited-${data.currentPackage.pkg.name.replace(" ", "-")}`
 		);
 		if (lastVisit) lastUpdateDate = new Date(lastVisit);
-		localStorage.setItem(
+		local.setItem(
 			`last-visited-${data.currentPackage.pkg.name.replace(" ", "-")}`,
 			new Date().toISOString()
 		);

--- a/src/routes/package/[...package]/ResetDialog.svelte
+++ b/src/routes/package/[...package]/ResetDialog.svelte
@@ -30,6 +30,7 @@
 	import { Checkbox } from "$lib/components/ui/checkbox";
 	import * as Dialog from "$lib/components/ui/dialog";
 	import { Label } from "$lib/components/ui/label";
+	import { local } from "$lib/storage";
 
 	type Props = {
 		currentPackage: string;
@@ -76,7 +77,7 @@
 			releases
 				.then(r => {
 					if (r) {
-						const lastVisitedItem = localStorage.getItem(`last-visited-${pkgName}`);
+						const lastVisitedItem = local.getItem(`last-visited-${pkgName}`);
 						if (lastVisitedItem) {
 							const lastVisitedDate = new Date(lastVisitedItem);
 							// will nuke visits if lastVisitedDate < resetDate (targetDate) && releases between them
@@ -109,8 +110,8 @@
 				pkgName.localeCompare(currentPackage, undefined, { sensitivity: "base" }) !== 0
 			)
 				continue;
-			const item = localStorage.getItem(`last-visited-${pkgName}`);
-			if (item) localStorage.setItem(`last-visited-${pkgName}`, targetDate.toISOString());
+			const item = local.getItem(`last-visited-${pkgName}`);
+			if (item) local.setItem(`last-visited-${pkgName}`, targetDate.toISOString());
 		}
 
 		// refresh the page with the removed query param

--- a/src/routes/package/settings.svelte.ts
+++ b/src/routes/package/settings.svelte.ts
@@ -1,5 +1,6 @@
 import { createContext } from "svelte";
 import { PersistedState } from "runed";
+import { local } from "$lib/storage";
 import type { PackageSettings } from "$lib/types";
 
 const DEFAULT_SETTINGS: PackageSettings = {
@@ -40,7 +41,7 @@ class PackagesSettings {
 			for (const k of Object.keys(DEFAULT_SETTINGS)) {
 				if (!(k in storedValue.current)) {
 					defaultSettings = { ...DEFAULT_SETTINGS, ...storedValue.current };
-					localStorage.removeItem(key);
+					local.removeItem(key);
 					skip = true;
 					break;
 				}


### PR DESCRIPTION
Topic brought to my attention from [this Bluesky post](https://bsky.app/profile/britegrid.io/post/3mpsembi2om22).
[svelte.dev](https://svelte.dev) fixed that through https://github.com/sveltejs/svelte.dev/pull/2081 and https://github.com/sveltejs/svelte.dev/pull/2082.

However, I can't merge this as easily as I would've liked, because some libraries I use depend themselves on raw `localStorage`/`sessionStorage` access (hence the PR):
- [`mode-watcher`](https://github.com/svecosystem/mode-watcher): opened https://github.com/svecosystem/mode-watcher/pull/167 for this
- [`posthog-js`](https://github.com/PostHog/posthog-js/tree/main/packages/browser): [already](https://github.com/PostHog/posthog-js/blob/050d495bcfd34f12ac9bb8520f7e15fa15cf853d/packages/browser/src/storage.ts#L181-L191) performs safe access
- [`runed`](https://github.com/svecosystem/runed): opened https://github.com/svecosystem/runed/pull/427 for this