### PR TITLE
feat(details): allow expanding diff hunks by clicking on them

### DIFF
--- a/src/routes/[pid=pid]/[org]/[repo]/[id=number]/DiffRenderer.svelte
+++ b/src/routes/[pid=pid]/[org]/[repo]/[id=number]/DiffRenderer.svelte
@@ -100,6 +100,13 @@
     				}
     			`,
 				disableErrorHandling: true,
+				loadDiffFiles: async metadata => {
+					const response = await fetch("/api/files?path=" + encodeURIComponent(metadata.name));
+
+					// Return { oldFile, newFile }, or { oldFile: null, newFile }
+					// for pure renames.
+					return { oldFile, newFile };
+				},
 				...options
 			},
 			getWorker({ ...options, langs })


### PR DESCRIPTION
It's a feature native to [`@pierre/diffs`](https://diffs.com) since day one, but [version 1.3.0](https://github.com/pierrecomputer/pierre/releases/tag/diffs-v1.3.0) made it way easier to implement (and actually doable here) when using raw GitHub diffs with partial-diff hydration, which is what I do.

In PR because it needs remote functions to fetch files from the server, which I'm bringing in with #220 👀