### PR TITLE
fix: hoist extraFileExtensions to avoid TS project reloads

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,7 +85,8 @@ export default defineConfig(
 	{
 		languageOptions: {
 			parserOptions: {
-				projectService: true
+				projectService: true,
+				extraFileExtensions: [".svelte"]
 			},
 			globals: {
 				...globals.browser,


### PR DESCRIPTION
I was looking at Svelte projects with slow ESLint runs and yours looks like it's hitting a known issue, so here's the fix.

`extraFileExtensions` was only set on the `.svelte` block, while `projectService` is also set on the shared block above it. So as ESLint walks between `.ts` and `.svelte` files the value flips between `[]` and `[".svelte"]`, and each flip reloads the whole TypeScript project.

Adding it to the shared block makes both resolve to the same value. I left the existing `.svelte` one alone, since it does no harm and keeps this to a single line.

Running `eslint .` locally before and after, I get roughly 225s down to 21s, with identical output.

Background on why the placement comes from the docs: https://github.com/sveltejs/eslint-plugin-svelte/issues/1575